### PR TITLE
Create custom content type and fields

### DIFF
--- a/config/sync/core.base_field_override.node.services.title.yml
+++ b/config/sync/core.base_field_override.node.services.title.yml
@@ -1,0 +1,18 @@
+uuid: f120dbfc-98c8-43aa-a7bc-3e275a5bac84
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.services
+id: node.services.title
+field_name: title
+entity_type: node
+bundle: services
+label: 'Service Name'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.entity_form_display.node.services.default.yml
+++ b/config/sync/core.entity_form_display.node.services.default.yml
@@ -1,0 +1,75 @@
+uuid: 943acad4-d08b-481c-89ce-63c00b624c22
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.services.body
+    - node.type.services
+  module:
+    - path
+    - text
+id: node.services.default
+targetEntityType: node
+bundle: services
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_form_display.node.services.default.yml
+++ b/config/sync/core.entity_form_display.node.services.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.services.body
+    - field.field.node.services.field_marketing_headline
     - node.type.services
   module:
     - path
@@ -28,6 +29,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_marketing_headline:
+    weight: 122
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   path:
     type: path
     weight: 30

--- a/config/sync/core.entity_form_display.node.services.default.yml
+++ b/config/sync/core.entity_form_display.node.services.default.yml
@@ -5,8 +5,11 @@ dependencies:
   config:
     - field.field.node.services.body
     - field.field.node.services.field_marketing_headline
+    - field.field.node.services.field_primary_sales_email
+    - field.field.node.services.field_service_landing_page
     - node.type.services
   module:
+    - link
     - path
     - text
 id: node.services.default
@@ -36,6 +39,22 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_primary_sales_email:
+    weight: 124
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_service_landing_page:
+    weight: 123
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
   path:
     type: path

--- a/config/sync/core.entity_form_display.node.services.default.yml
+++ b/config/sync/core.entity_form_display.node.services.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.services.field_marketing_headline
     - field.field.node.services.field_operational_date
     - field.field.node.services.field_primary_sales_email
+    - field.field.node.services.field_related_articles
     - field.field.node.services.field_sales_telephon
     - field.field.node.services.field_service_landing_page
     - node.type.services
@@ -57,6 +58,15 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_related_articles:
+    weight: 127
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_sales_telephon:
     weight: 125

--- a/config/sync/core.entity_form_display.node.services.default.yml
+++ b/config/sync/core.entity_form_display.node.services.default.yml
@@ -5,12 +5,16 @@ dependencies:
   config:
     - field.field.node.services.body
     - field.field.node.services.field_marketing_headline
+    - field.field.node.services.field_operational_date
     - field.field.node.services.field_primary_sales_email
+    - field.field.node.services.field_sales_telephon
     - field.field.node.services.field_service_landing_page
     - node.type.services
   module:
+    - datetime
     - link
     - path
+    - telephone
     - text
 id: node.services.default
 targetEntityType: node
@@ -40,6 +44,12 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_operational_date:
+    weight: 126
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
   field_primary_sales_email:
     weight: 124
     settings:
@@ -47,6 +57,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_sales_telephon:
+    weight: 125
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: telephone_default
     region: content
   field_service_landing_page:
     weight: 123

--- a/config/sync/core.entity_view_display.node.services.default.yml
+++ b/config/sync/core.entity_view_display.node.services.default.yml
@@ -1,0 +1,26 @@
+uuid: e9124391-a90c-4262-a35f-58e22743e9ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.services.body
+    - node.type.services
+  module:
+    - text
+    - user
+id: node.services.default
+targetEntityType: node
+bundle: services
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.node.services.default.yml
+++ b/config/sync/core.entity_view_display.node.services.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.services.field_marketing_headline
     - field.field.node.services.field_operational_date
     - field.field.node.services.field_primary_sales_email
+    - field.field.node.services.field_related_articles
     - field.field.node.services.field_sales_telephon
     - field.field.node.services.field_service_landing_page
     - node.type.services
@@ -50,6 +51,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_related_articles:
+    weight: 107
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_sales_telephon:
     weight: 105

--- a/config/sync/core.entity_view_display.node.services.default.yml
+++ b/config/sync/core.entity_view_display.node.services.default.yml
@@ -5,8 +5,11 @@ dependencies:
   config:
     - field.field.node.services.body
     - field.field.node.services.field_marketing_headline
+    - field.field.node.services.field_primary_sales_email
+    - field.field.node.services.field_service_landing_page
     - node.type.services
   module:
+    - link
     - text
     - user
 id: node.services.default
@@ -28,6 +31,25 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_primary_sales_email:
+    weight: 104
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_service_landing_page:
+    weight: 103
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
     region: content
   links:
     weight: 100

--- a/config/sync/core.entity_view_display.node.services.default.yml
+++ b/config/sync/core.entity_view_display.node.services.default.yml
@@ -5,10 +5,13 @@ dependencies:
   config:
     - field.field.node.services.body
     - field.field.node.services.field_marketing_headline
+    - field.field.node.services.field_operational_date
     - field.field.node.services.field_primary_sales_email
+    - field.field.node.services.field_sales_telephon
     - field.field.node.services.field_service_landing_page
     - node.type.services
   module:
+    - datetime
     - link
     - text
     - user
@@ -32,12 +35,29 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  field_operational_date:
+    weight: 106
+    label: above
+    settings:
+      timezone_override: America/New_York
+      format_type: medium
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
   field_primary_sales_email:
     weight: 104
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_sales_telephon:
+    weight: 105
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_service_landing_page:
     weight: 103
@@ -54,4 +74,6 @@ content:
   links:
     weight: 100
     region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_view_display.node.services.default.yml
+++ b/config/sync/core.entity_view_display.node.services.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.services.body
+    - field.field.node.services.field_marketing_headline
     - node.type.services
   module:
     - text
@@ -19,6 +20,14 @@ content:
     weight: 101
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_marketing_headline:
+    weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   links:
     weight: 100

--- a/config/sync/core.entity_view_display.node.services.teaser.yml
+++ b/config/sync/core.entity_view_display.node.services.teaser.yml
@@ -1,0 +1,28 @@
+uuid: d3676999-445c-4af0-bd91-72eb1b413383
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.services.body
+    - node.type.services
+  module:
+    - text
+    - user
+id: node.services.teaser
+targetEntityType: node
+bundle: services
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -36,6 +36,7 @@ module:
   simpletest: 0
   system: 0
   taxonomy: 0
+  telephone: 0
   text: 0
   token: 0
   toolbar: 0

--- a/config/sync/field.field.node.services.body.yml
+++ b/config/sync/field.field.node.services.body.yml
@@ -1,0 +1,22 @@
+uuid: 95b30039-57c9-4803-bf76-2ef81b038099
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.services
+  module:
+    - text
+id: node.services.body
+field_name: body
+entity_type: node
+bundle: services
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/config/sync/field.field.node.services.field_marketing_headline.yml
+++ b/config/sync/field.field.node.services.field_marketing_headline.yml
@@ -1,0 +1,19 @@
+uuid: 6307ce35-ad54-4a46-9f2e-8b9997cb34af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_marketing_headline
+    - node.type.services
+id: node.services.field_marketing_headline
+field_name: field_marketing_headline
+entity_type: node
+bundle: services
+label: 'Marketing headline'
+description: 'This field is displayed on marketing landing pages'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.services.field_operational_date.yml
+++ b/config/sync/field.field.node.services.field_operational_date.yml
@@ -1,0 +1,24 @@
+uuid: 0d5be6ff-72d3-4ce8-8c46-c4d889c65a71
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_operational_date
+    - node.type.services
+  module:
+    - datetime
+id: node.services.field_operational_date
+field_name: field_operational_date
+entity_type: node
+bundle: services
+label: 'Operational Date'
+description: 'This is the date this service became available. Because we beta test these services prior to adding them, the default operational date is 30 days PRIOR to today''s date.'
+required: false
+translatable: false
+default_value:
+  -
+    default_date_type: relative
+    default_date: '-30 days'
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.services.field_primary_sales_email.yml
+++ b/config/sync/field.field.node.services.field_primary_sales_email.yml
@@ -1,0 +1,21 @@
+uuid: 5ed9847f-b3a3-4dbd-b6b0-0190c241632e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_primary_sales_email
+    - node.type.services
+id: node.services.field_primary_sales_email
+field_name: field_primary_sales_email
+entity_type: node
+bundle: services
+label: 'Primary Sales Email'
+description: 'Enter the email address of the primary sales representative for this service.'
+required: true
+translatable: false
+default_value:
+  -
+    value: sales@mycompany.com
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/sync/field.field.node.services.field_related_articles.yml
+++ b/config/sync/field.field.node.services.field_related_articles.yml
@@ -1,0 +1,28 @@
+uuid: bca98f52-baeb-4156-9d5d-1517231ddf4c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_articles
+    - node.type.article
+    - node.type.services
+id: node.services.field_related_articles
+field_name: field_related_articles
+entity_type: node
+bundle: services
+label: 'Related Articles'
+description: 'Select blog posts (articles) that you wish to display with this service.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      article: article
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.services.field_sales_telephon.yml
+++ b/config/sync/field.field.node.services.field_sales_telephon.yml
@@ -1,0 +1,21 @@
+uuid: 97dac7ef-ed56-4251-a4bf-f3c33d2b4b5d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sales_telephon
+    - node.type.services
+  module:
+    - telephone
+id: node.services.field_sales_telephon
+field_name: field_sales_telephon
+entity_type: node
+bundle: services
+label: 'Sales Phone Number'
+description: 'Primary phone number for this services sales department'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: telephone

--- a/config/sync/field.field.node.services.field_service_landing_page.yml
+++ b/config/sync/field.field.node.services.field_service_landing_page.yml
@@ -1,0 +1,23 @@
+uuid: 54de4a26-5c6c-4504-8f5c-1fc1ffd5d160
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_service_landing_page
+    - node.type.services
+  module:
+    - link
+id: node.services.field_service_landing_page
+field_name: field_service_landing_page
+entity_type: node
+bundle: services
+label: 'Service Landing Page'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/sync/field.storage.node.field_marketing_headline.yml
+++ b/config/sync/field.storage.node.field_marketing_headline.yml
@@ -1,0 +1,21 @@
+uuid: f82d3b1b-8495-413c-8949-eae4e02d60e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_marketing_headline
+field_name: field_marketing_headline
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_operational_date.yml
+++ b/config/sync/field.storage.node.field_operational_date.yml
@@ -1,0 +1,20 @@
+uuid: 1693f42f-7459-49b1-88cd-cdca28c01a70
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_operational_date
+field_name: field_operational_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_primary_sales_email.yml
+++ b/config/sync/field.storage.node.field_primary_sales_email.yml
@@ -1,0 +1,18 @@
+uuid: 1d0dcc2f-d567-4f5f-92ec-13d89856f5a9
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_primary_sales_email
+field_name: field_primary_sales_email
+entity_type: node
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_related_articles.yml
+++ b/config/sync/field.storage.node.field_related_articles.yml
@@ -1,0 +1,19 @@
+uuid: fec98f31-2f86-4a7b-889c-63783f8841b1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_related_articles
+field_name: field_related_articles
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_sales_telephon.yml
+++ b/config/sync/field.storage.node.field_sales_telephon.yml
@@ -1,0 +1,19 @@
+uuid: 46b7a9ea-171b-4f25-b7b3-6fe1cab31f5c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - telephone
+id: node.field_sales_telephon
+field_name: field_sales_telephon
+entity_type: node
+type: telephone
+settings: {  }
+module: telephone
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_service_landing_page.yml
+++ b/config/sync/field.storage.node.field_service_landing_page.yml
@@ -1,0 +1,19 @@
+uuid: 2916f0cb-a140-46a6-adfd-96651ca3e4db
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_service_landing_page
+field_name: field_service_landing_page
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.services.yml
+++ b/config/sync/node.type.services.yml
@@ -1,0 +1,18 @@
+uuid: 68bb576e-223b-4841-a27f-e41d08b83f86
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Services
+type: services
+description: 'The companies services'
+help: ''
+new_revision: true
+preview_mode: 2
+display_submitted: false


### PR DESCRIPTION
Adds _services_ content type as well as fields for: 
- Marketing headline (text -> plain)
- Sales Email (email)
- Sales Telephone (enabled telephone module)
- Release Date field (date only)
- Related Articles (entity reference)
